### PR TITLE
go-proio: Improved Reader.Events() scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ func main() {
         log.Fatal(err)
     }
 
-    for event := range reader.Events() {
+    for event := range reader.ScanEvents() {
         if reader.Err != nil {
             log.Println(reader.Err)
         }

--- a/README.md
+++ b/README.md
@@ -149,10 +149,6 @@ func main() {
     }
 
     for event := range reader.ScanEvents() {
-        if reader.Err != nil {
-            log.Println(reader.Err)
-        }
-
         mcColl := event.Get("MCParticle").(*model.MCParticleCollection)
         if mcColl == nil || len(mcColl.Entries) < 1 {
             continue

--- a/go-proio/proio-ls/main.go
+++ b/go-proio/proio-ls/main.go
@@ -66,7 +66,7 @@ func main() {
 
 	nEventsRead := 0
 
-	for event := range reader.Events() {
+	for event := range reader.ScanEvents() {
 		if reader.Err != nil {
 			log.Print(reader.Err)
 		}
@@ -75,6 +75,7 @@ func main() {
 
 		nEventsRead++
 		if singleEvent {
+			reader.StopScan()
 			break
 		}
 	}

--- a/go-proio/proio-ls/main.go
+++ b/go-proio/proio-ls/main.go
@@ -67,10 +67,6 @@ func main() {
 	nEventsRead := 0
 
 	for event := range reader.ScanEvents() {
-		if reader.Err != nil {
-			log.Print(reader.Err)
-		}
-
 		fmt.Print(event)
 
 		nEventsRead++
@@ -80,7 +76,15 @@ func main() {
 		}
 	}
 
-	if (reader.Err != nil && reader.Err != io.EOF) || nEventsRead == 0 {
-		log.Print(reader.Err)
+errLoop:
+	for {
+		select {
+		case err := <-reader.Err:
+			if err != io.EOF || nEventsRead == 0 {
+				log.Print(err)
+			}
+		default:
+			break errLoop
+		}
 	}
 }

--- a/go-proio/proio-strip/main.go
+++ b/go-proio/proio-strip/main.go
@@ -77,7 +77,7 @@ func main() {
 
 	nEventsRead := 0
 
-	for event := range reader.Events() {
+	for event := range reader.ScanEvents() {
 		if reader.Err != nil {
 			log.Print(reader.Err)
 		}

--- a/go-proio/proio_test.go
+++ b/go-proio/proio_test.go
@@ -303,9 +303,6 @@ func BenchmarkTrackingLCIO(b *testing.B) {
 func tracking(reader *Reader, b *testing.B) {
 	b.N = 0
 	for event := range reader.ScanEvents() {
-		if reader.Err != nil {
-			break
-		}
 		b.N++
 
 		truthColl := event.Get("MCParticle").(*model.MCParticleCollection)

--- a/go-proio/proio_test.go
+++ b/go-proio/proio_test.go
@@ -301,12 +301,12 @@ func BenchmarkTrackingLCIO(b *testing.B) {
 }
 
 func tracking(reader *Reader, b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		event, err := reader.Get()
-		if err != nil {
-			b.N = i
+	b.N = 0
+	for event := range reader.ScanEvents() {
+		if reader.Err != nil {
 			break
 		}
+		b.N++
 
 		truthColl := event.Get("MCParticle").(*model.MCParticleCollection)
 		trackColl := event.Get("Tracks").(*model.TrackCollection)

--- a/go-proio/reader.go
+++ b/go-proio/reader.go
@@ -7,14 +7,18 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/decibelcooper/proio/go-proio/model"
 )
 
 type Reader struct {
-	Err                error
-	byteReader         io.Reader
-	deferredUntilClose []func() error
+	Err                   error
+	EventScanBufferSize   int
+	byteReader            io.Reader
+	deferredUntilClose    []func() error
+	deferredUntilStopScan []func()
+	getMutex              sync.Mutex
 }
 
 // Opens a file and adds the file as an io.Reader to a new Reader that is
@@ -44,6 +48,8 @@ func Open(filename string) (*Reader, error) {
 
 // Closes anything created by Open() or NewGzipReader()
 func (rdr *Reader) Close() error {
+	rdr.StopScan()
+
 	for _, thisFunc := range rdr.deferredUntilClose {
 		if err := thisFunc(); err != nil {
 			return err
@@ -59,7 +65,8 @@ func (rdr *Reader) deferUntilClose(thisFunc func() error) {
 // Returns a new Reader for reading events from a stream
 func NewReader(byteReader io.Reader) *Reader {
 	return &Reader{
-		byteReader: byteReader,
+		byteReader:          byteReader,
+		EventScanBufferSize: 100,
 	}
 }
 
@@ -120,6 +127,9 @@ var (
 // the beginning of an event, the stream will be resynchronized to the next
 // event, and ErrResync will be returned along with the event.
 func (rdr *Reader) Get() (*Event, error) {
+	rdr.getMutex.Lock()
+	defer rdr.getMutex.Unlock()
+
 	n, err := rdr.syncToMagic()
 	if err != nil {
 		return nil, err
@@ -159,27 +169,63 @@ func (rdr *Reader) Get() (*Event, error) {
 	}
 
 	rdr.Err = err
+
 	return event, err
 }
 
-//Events returns a channel of type Event where all of the events in the stream
-//will be pushed.  For error checking in this iteration scheme, check
-//Reader.Err.
-func (rdr *Reader) Events() <-chan *Event {
-	events := make(chan *Event)
+//ScanEvents returns a buffered channel of type Event where all of the events
+//in the stream will be pushed.  The channel buffer size is defined by
+//Reader.EventScanBufferSize which defaults to 100.  The goroutine responsible
+//for fetching events will not break until there are no more events,
+//Reader.StopScan() is called, or Reader.Close() is called.  For error checking
+//in this iteration scheme, check Reader.Err.
+func (rdr *Reader) ScanEvents() <-chan *Event {
+	events := make(chan *Event, rdr.EventScanBufferSize)
+	quit := make(chan int)
+
 	go func() {
-		for event, _ := rdr.Get(); event != nil; event, _ = rdr.Get() {
-			events <- event
+		defer close(events)
+		for {
+			event, _ := rdr.Get()
+			if event == nil {
+				return
+			}
+			select {
+			case events <- event:
+			case <-quit:
+				return
+			}
 		}
-		close(events)
 	}()
+
+	rdr.deferUntilStopScan(
+		func() {
+			close(quit)
+		},
+	)
+
 	return events
+}
+
+func (rdr *Reader) deferUntilStopScan(thisFunc func()) {
+	rdr.deferredUntilStopScan = append(rdr.deferredUntilStopScan, thisFunc)
+}
+
+// StopScan stops all scans initiated by Reader.ScanEvents()
+func (rdr *Reader) StopScan() {
+	for _, thisFunc := range rdr.deferredUntilStopScan {
+		thisFunc()
+	}
+	rdr.deferredUntilStopScan = make([]func(), 0)
 }
 
 // Get the next Header only from the stream, and seek past the collection
 // payload if possible.  This is useful for parsing the metadata of a file or
 // stream.
 func (rdr *Reader) GetHeader() (*model.EventHeader, error) {
+	rdr.getMutex.Lock()
+	defer rdr.getMutex.Unlock()
+
 	n, err := rdr.syncToMagic()
 	if err != nil {
 		return nil, err
@@ -223,11 +269,15 @@ func (rdr *Reader) GetHeader() (*model.EventHeader, error) {
 		err = nil
 	}
 
+	rdr.getMutex.Unlock()
 	return header, err
 }
 
 // Skip the next nEvents events
 func (rdr *Reader) Skip(nEvents int) (int, error) {
+	rdr.getMutex.Lock()
+	defer rdr.getMutex.Unlock()
+
 	seeker, isSeeker := rdr.byteReader.(io.Seeker)
 	wasResynced := false
 
@@ -280,6 +330,9 @@ var ErrNotSeekable = errors.New("data stream is not seekable")
 // If the stream implements io.Seeker (typically a file), reset back to the
 // beginning of the file.
 func (rdr *Reader) SeekToStart() error {
+	rdr.getMutex.Lock()
+	defer rdr.getMutex.Unlock()
+
 	seeker, ok := rdr.byteReader.(io.Seeker)
 	if !ok {
 		return ErrNotSeekable
@@ -294,6 +347,7 @@ func (rdr *Reader) SeekToStart() error {
 			break
 		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
As pointed out by @sbinet, Reader.Events() allowed for leaking
goroutines if the channel was not exhausted.  This has been resolved by
adding the ability to stop the scan and close the channel.

Reader.Events() has been renamed to Reader.ScanEvents(), and another
function Reader.StopScan() has been added.  Additionally, Reader.Close()
will call Reader.StopScan().  A mutex for entering Reader.Get()-like
functions has been added for thread safety and to allow multiple
scanners to exist simultaneously.

Finally, the channel has been made buffered, and the variable
Reader.EventScanBufferSize has been added with a default value of 100.
This can be used to customize the depth of the buffered channel.

This PR resolves #6 