### PR TITLE
tools: proio-strip: improved behavior with tags

### DIFF
--- a/go-proio/proio-strip/main.go
+++ b/go-proio/proio-strip/main.go
@@ -14,12 +14,19 @@ import (
 var (
 	outFile   = flag.String("o", "", "file to save output to")
 	keep      = flag.Bool("k", false, "keep only entries with the specified tags, rather than stripping them away")
-	compLevel = flag.Int("c", 1, "compression level: 0 for uncompressed, 1 for LZ4 compression, 2 for GZIP compression")
+	compLevel = flag.Int("c", 1, "output compression level: 0 for uncompressed, 1 for LZ4 compression, 2 for GZIP compression")
 )
 
 func printUsage() {
 	fmt.Fprintf(os.Stderr,
-		`Usage: proio-strip [options] <proio-input-file> <tags>...
+		`Usage: proio-strip [options] <proio-input-file> [tags...]
+
+proio-strip will take an input proio file and either strip away entries with
+specific tags, or keep only entries with specific tags.  It can also be used to
+simply re-encode the proio stream by omitting tags.  By default, the output
+stream is pushed to stdout, but the -o option can be used to create a file
+descriptor for a specified path.
+
 options:
 `,
 	)

--- a/go-proio/proio-strip/main.go
+++ b/go-proio/proio-strip/main.go
@@ -79,9 +79,7 @@ func main() {
 	for event := range reader.ScanEvents() {
 		if *keep {
 			keepTagIDs := make(map[uint64]bool)
-			keepTags := make(map[string]bool)
 			for _, keepTag := range argTags {
-				keepTags[keepTag] = true
 				for _, entryID := range event.TaggedEntries(keepTag) {
 					keepTagIDs[entryID] = true
 				}
@@ -91,17 +89,17 @@ func main() {
 					event.RemoveEntry(entryID)
 				}
 			}
-			for _, tag := range event.Tags() {
-				if !keepTags[tag] {
-					event.DeleteTag(tag)
-				}
-			}
 		} else {
 			for _, removeTag := range argTags {
 				for _, entryID := range event.TaggedEntries(removeTag) {
 					event.RemoveEntry(entryID)
 				}
-				event.DeleteTag(removeTag)
+			}
+		}
+
+		for _, tag := range event.Tags() {
+			if len(event.TaggedEntries(tag)) == 0 {
+				event.DeleteTag(tag)
 			}
 		}
 


### PR DESCRIPTION
Now tags are only removed from the event if they don't point to any remaining entries