### PR TITLE
cpp-proio: fixed bad return value and mem leak

### DIFF
--- a/cpp-proio/src/event.cc
+++ b/cpp-proio/src/event.cc
@@ -69,8 +69,14 @@ std::vector<std::string> Event::Tags() {
     return tags;
 }
 
-const RepeatedField<uint64_t> &Event::TaggedEntries(std::string tag) {
-    if (eventProto->tags().count(tag)) return eventProto->tags().at(tag).entries();
+std::vector<uint64_t> Event::TaggedEntries(std::string tag) {
+    if (eventProto->tags().count(tag)) {
+        auto entries = eventProto->tags().at(tag).entries();
+        std::vector<uint64_t> returnEntries;
+        for (uint64_t entry : entries) returnEntries.push_back(entry);
+        return returnEntries;
+    }
+    return std::vector<uint64_t>();
 }
 
 std::string Event::String() {
@@ -108,6 +114,7 @@ void Event::flushCollCache() {
         delete entry;
 
         (*eventProto->mutable_entries())[id].set_payload(buffer, byteSize);
+        delete[] buffer;
     }
     entryCache.clear();
 }

--- a/cpp-proio/src/event.h
+++ b/cpp-proio/src/event.h
@@ -31,7 +31,7 @@ class Event {
     /** TaggedEntries tages a tag string and returns a list of entry IDs that
      * the tag references.
      */
-    const google::protobuf::RepeatedField<uint64_t> &TaggedEntries(std::string tag);
+    std::vector<uint64_t> TaggedEntries(std::string tag);
 
     /** String returns a human-readable string representing the event.
      */


### PR DESCRIPTION
Bad return value occured when the tag given to TaggedEntries() wasn't found.  Also, the return type was changed to std::vector<uint64_t>

Fixed memory leak while flushing event collection cache