### PR TITLE
go-proio fixes/improvements

### DIFF
--- a/go-proio/bench_test.go
+++ b/go-proio/bench_test.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/decibelcooper/proio/go-proio/model/eic"
 	prolcio "github.com/decibelcooper/proio/go-proio/model/lcio"
 )
 
@@ -102,4 +103,40 @@ func BenchmarkReadGZIP(b *testing.B) {
 
 	reader := NewReader(buffer)
 	doRead(reader, b)
+}
+
+func BenchmarkAddRemove100Entries(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		event := NewEvent()
+		for i := 0; i < 100; i++ {
+			event.AddEntry("Particle", &eic.Particle{})
+		}
+		for i := 0; i < 100; i++ {
+			event.RemoveEntry(uint64(i + 1))
+		}
+	}
+}
+
+func BenchmarkAddRemove1000Entries(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		event := NewEvent()
+		for i := 0; i < 1000; i++ {
+			event.AddEntry("Particle", &eic.Particle{})
+		}
+		for i := 0; i < 1000; i++ {
+			event.RemoveEntry(uint64(i + 1))
+		}
+	}
+}
+
+func BenchmarkAddRemove10000Entries(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		event := NewEvent()
+		for i := 0; i < 10000; i++ {
+			event.AddEntry("Particle", &eic.Particle{})
+		}
+		for i := 0; i < 10000; i++ {
+			event.RemoveEntry(uint64(i + 1))
+		}
+	}
 }

--- a/go-proio/bench_test.go
+++ b/go-proio/bench_test.go
@@ -106,36 +106,28 @@ func BenchmarkReadGZIP(b *testing.B) {
 }
 
 func BenchmarkAddRemove100Entries(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		event := NewEvent()
-		for i := 0; i < 100; i++ {
-			event.AddEntry("Particle", &eic.Particle{})
-		}
-		for i := 0; i < 100; i++ {
-			event.RemoveEntry(uint64(i + 1))
-		}
-	}
+	addRemoveNEntries(b, 100)
 }
 
 func BenchmarkAddRemove1000Entries(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		event := NewEvent()
-		for i := 0; i < 1000; i++ {
-			event.AddEntry("Particle", &eic.Particle{})
-		}
-		for i := 0; i < 1000; i++ {
-			event.RemoveEntry(uint64(i + 1))
-		}
-	}
+	addRemoveNEntries(b, 1000)
 }
 
 func BenchmarkAddRemove10000Entries(b *testing.B) {
+	addRemoveNEntries(b, 10000)
+}
+
+func BenchmarkAddRemove100000Entries(b *testing.B) {
+	addRemoveNEntries(b, 100000)
+}
+
+func addRemoveNEntries(b *testing.B, n int) {
 	for i := 0; i < b.N; i++ {
 		event := NewEvent()
-		for i := 0; i < 10000; i++ {
+		for i := 0; i < n; i++ {
 			event.AddEntry("Particle", &eic.Particle{})
 		}
-		for i := 0; i < 10000; i++ {
+		for i := 0; i < n; i++ {
 			event.RemoveEntry(uint64(i + 1))
 		}
 	}

--- a/go-proio/event.go
+++ b/go-proio/event.go
@@ -124,8 +124,7 @@ func (evt *Event) GetEntry(id uint64) protobuf.Message {
 }
 
 func (evt *Event) RemoveEntry(id uint64) {
-	tags := evt.EntryTags(id)
-	for _, tag := range tags {
+	for tag, _ := range evt.proto.Tags {
 		evt.UntagEntry(id, tag)
 	}
 
@@ -174,7 +173,9 @@ func (evt *Event) UntagEntry(id uint64, tag string) {
 func (evt *Event) TaggedEntries(tag string) []uint64 {
 	tagProto, ok := evt.proto.Tags[tag]
 	if ok {
-		return tagProto.Entries[:]
+		entries := make([]uint64, len(tagProto.Entries))
+		copy(entries, tagProto.Entries)
+		return entries
 	}
 	return nil
 }

--- a/go-proio/strip_test.go
+++ b/go-proio/strip_test.go
@@ -1,0 +1,26 @@
+package proio
+
+import (
+	"testing"
+
+	eic "github.com/decibelcooper/proio/go-proio/model/eic"
+)
+
+func TestStrip1(t *testing.T) {
+	event := NewEvent()
+	for i := 0; i < 100; i++ {
+		event.AddEntry(
+			"Particle",
+			&eic.Particle{},
+		)
+	}
+
+	for _, ID := range event.TaggedEntries("Particle") {
+		event.RemoveEntry(ID)
+	}
+
+	nEntries := len(event.AllEntries())
+	if nEntries > 0 {
+		t.Errorf("There should be no entries, but len(event.AllEntries()) = %v out of 100", nEntries)
+	}
+}


### PR DESCRIPTION
Issues were caused by the fact that (*Event) TaggedEntries() returned
the exact slice from the protobuf Tag object.  This causes an issue when
deleting entries in the iteration, and this caused a bug in proio-strip.
To resolve this, TaggedEntries() now makes a copy of the slice to
return.