### PR TITLE
cpp-proio: improved performance of removing entries

### DIFF
--- a/cpp-proio/src/event.cc
+++ b/cpp-proio/src/event.cc
@@ -185,9 +185,11 @@ uint64_t Event::getTypeID(Message *entry) {
 }
 
 const Descriptor *Event::getDescriptor(uint64_t typeID) {
-    if (descriptorCache.count(typeID)) return descriptorCache[typeID];
-    const std::string typeName = eventProto->types().at(typeID);
-    return DescriptorPool::generated_pool()->FindMessageTypeByName(typeName);
+    if (!descriptorCache.count(typeID)) {
+        const std::string typeName = eventProto->types().at(typeID);
+        descriptorCache[typeID] = DescriptorPool::generated_pool()->FindMessageTypeByName(typeName);
+    }
+    return descriptorCache[typeID];
 }
 
 void Event::tagCleanup() {

--- a/cpp-proio/src/event.h
+++ b/cpp-proio/src/event.h
@@ -62,11 +62,13 @@ class Event {
    private:
     uint64_t getTypeID(google::protobuf::Message *entry);
     const google::protobuf::Descriptor *getDescriptor(uint64_t typeID);
+    void tagCleanup();
 
     proto::Event *eventProto;
     std::map<std::string, uint64_t> revTypeLookup;
     std::map<uint64_t, google::protobuf::Message *> entryCache;
     std::map<uint64_t, const google::protobuf::Descriptor *> descriptorCache;
+    bool dirtyTags;
 };
 
 const class UnknownMessageTypeError : public std::exception {


### PR DESCRIPTION
Now the removal of entries is approximately linear with number of
entries removed.  Before it was pretty non-linear because each removed
entry was untagged on each call of RemoveEntry().  Instead, the tags are
flagged as dirty when an entry is removed, and cleaned up before
returning TaggedEntries() or serialization.