### PR TITLE
py-proio: Event: added missing methods for event manipulation

### DIFF
--- a/py-proio/proio/event.py
+++ b/py-proio/proio/event.py
@@ -60,15 +60,10 @@ class Event(object):
         :return: entry message object
         :rtype: :class:`google.protobuf.message.Message`
         """
-        try:
+        if ID in self._entry_cache:
             return self._entry_cache[ID]
-        except KeyError:
-            pass
-
-        try:
+        if ID in self._proto.entries:
             entry_proto = self._proto.entries[ID]
-        except KeyError:
-            return
 
         type_string = self._proto.types[entry_proto.type]
         type_desc = descriptor_pool.Default().FindMessageTypeByName(type_string)

--- a/py-proio/setup.py
+++ b/py-proio/setup.py
@@ -7,7 +7,7 @@ models = ['proio.model.' + splitext(basename(model))[0] for model in glob('proio
 models = list(filter(lambda model: model != 'proio.model.__init__', models))
 
 setup(name='proio',
-      version='0.6.1',
+      version='0.7.0',
       description='Library for reading and writing proio files and streams',
       url='http://github.com/decibelcooper/proio',
       author='David Blyth',

--- a/py-proio/tests/test_push_get.py
+++ b/py-proio/tests/test_push_get.py
@@ -10,6 +10,9 @@ def test_push_get1_lz4():
 def test_push_get2_lz4():
     push_get2(proio.LZ4)
 
+def test_push_get3_lz4():
+    push_get3(proio.LZ4)
+
 def test_push_skip_get1_lz4():
     push_skip_get1(proio.LZ4)
 
@@ -22,6 +25,9 @@ def test_push_get1_gzip():
 def test_push_get2_gzip():
     push_get2(proio.GZIP)
 
+def test_push_get3_gzip():
+    push_get3(proio.GZIP)
+
 def test_push_skip_get1_gzip():
     push_skip_get1(proio.GZIP)
 
@@ -33,6 +39,9 @@ def test_push_get1_uncompressed():
 
 def test_push_get2_uncompressed():
     push_get2(proio.UNCOMPRESSED)
+
+def test_push_get3_uncompressed():
+    push_get3(proio.UNCOMPRESSED)
 
 def test_push_skip_get1_uncompressed():
     push_skip_get1(proio.UNCOMPRESSED)
@@ -112,6 +121,53 @@ def push_get2(comp):
     buf.seek(0, 0)
 
     with proio.Reader(fileobj = buf) as reader:
+        for i in range(0, len(eventsOut)):
+            event = reader.next()
+            assert event != None
+            assert event.__str__() == eventsOut[i].__str__()
+
+def push_get3(comp):
+    buf = io.BytesIO(b'')
+    with proio.Writer(fileobj = buf) as writer:
+        writer.set_compression(comp)
+
+        event = proio.Event()
+        event.add_entries(
+                'MCParticle',
+                prolcio.MCParticle(),
+                prolcio.MCParticle()
+                )
+        event.add_entries(
+                'TrackerHits',
+                prolcio.SimTrackerHit(),
+                prolcio.SimTrackerHit()
+                )
+        writer.push(event)
+        
+        event = proio.Event()
+        event.add_entry(
+                'TrackerHits',
+                prolcio.SimTrackerHit(),
+                )
+        writer.push(event)
+
+    buf.seek(0, 0)
+    buf2 = io.BytesIO(b'')
+
+    with proio.Reader(fileobj = buf) as reader:
+        with proio.Writer(fileobj = buf2) as writer:
+            eventsOut = []
+            for event in reader:
+                event.add_entry(
+                        'TrackerHits',
+                        prolcio.SimTrackerHit(),
+                        )
+                eventsOut.append(event)
+                writer.push(event)
+
+    buf2.seek(0, 0)
+
+    with proio.Reader(fileobj = buf2) as reader:
         for i in range(0, len(eventsOut)):
             event = reader.next()
             assert event != None

--- a/py-proio/tests/test_tags.py
+++ b/py-proio/tests/test_tags.py
@@ -1,0 +1,79 @@
+import pytest
+
+import proio
+import proio.model.eic as eic
+
+def test_tag_cleanup1():
+    event = proio.Event()
+    entry = eic.SimHit()
+    entryID = event.add_entry('SimCreated', entry)
+    assert(len(event.tagged_entries('SimCreated')) == 1)
+    assert(len(event.all_entries()) == 1)
+    event.remove_entry(entryID)
+    assert(len(event.tagged_entries('SimCreated')) == 0)
+    assert(len(event.all_entries()) == 0)
+
+def test_tag_cleanup2():
+    event = proio.Event()
+    entry = eic.SimHit()
+    entryID = event.add_entry('SimCreated', entry)
+    event._flush_cache()
+    assert(len(event.tagged_entries('SimCreated')) == 1)
+    assert(len(event.all_entries()) == 1)
+    event.remove_entry(entryID)
+    assert(len(event.tagged_entries('SimCreated')) == 0)
+    assert(len(event.all_entries()) == 0)
+
+def test_untag1():
+    event = proio.Event()
+    entry = eic.SimHit()
+    entryID = event.add_entry('SimCreated', entry)
+    assert(len(event.tagged_entries('SimCreated')) == 1)
+    event.untag_entry(entryID, 'WrongTag')
+    assert(len(event.tagged_entries('SimCreated')) == 1)
+    assert(len(event.tags()) == 1)
+    assert(len(event.all_entries()) == 1)
+    event.untag_entry(entryID, 'SimCreated')
+    assert(len(event.tagged_entries('SimCreated')) == 0)
+    assert(len(event.all_entries()) == 1)
+
+def test_untag2():
+    event = proio.Event()
+    entry = eic.SimHit()
+    entryID = event.add_entry('SimCreated', entry)
+    assert(len(event.tagged_entries('SimCreated')) == 1)
+    event.untag_entry(entryID + 1, 'WrongTag')
+    assert(len(event.tagged_entries('SimCreated')) == 1)
+    assert(len(event.tags()) == 1)
+    assert(len(event.all_entries()) == 1)
+    event.untag_entry(entryID + 1, 'SimCreated')
+    assert(len(event.tagged_entries('SimCreated')) == 1)
+    assert(len(event.all_entries()) == 1)
+
+def test_tag_delete1():
+    event = proio.Event()
+    entry = eic.SimHit()
+    entryID = event.add_entry('SimCreated', entry)
+    assert(len(event.tags()) == 1)
+    assert(len(event.all_entries()) == 1)
+    event.delete_tag('WrongTag')
+    assert(len(event.tags()) == 1)
+    event.delete_tag('SimCreated')
+    assert(len(event.tags()) == 0)
+    assert(len(event.all_entries()) == 1)
+
+def test_tag_rev_lookup1():
+    event = proio.Event()
+    entry = eic.SimHit()
+    entryID = event.add_entry('SimCreated', entry)
+    assert(len(event.entry_tags(entryID)) == 1)
+    assert(event.entry_tags(entryID)[0] == 'SimCreated')
+    assert(len(event.tags()) == 1)
+    event.tag_entry(entryID, 'Tracker')
+    assert(len(event.entry_tags(entryID)) == 2)
+    assert(len(event.tags()) == 2)
+    event.untag_entry(entryID, 'SimCreated')
+    assert(len(event.entry_tags(entryID)) == 1)
+    assert(event.entry_tags(entryID)[0] == 'Tracker')
+    assert(len(event.tags()) == 2)
+


### PR DESCRIPTION
This PR resolves #41 