### PR TITLE
cpp-proio: added thread protection to reader and writer

### DIFF
--- a/cpp-proio/src/reader.h
+++ b/cpp-proio/src/reader.h
@@ -1,6 +1,7 @@
 #ifndef PROIO_READER_H
 #define PROIO_READER_H
 
+#include <pthread.h>
 #include <cstring>
 #include <string>
 
@@ -75,6 +76,8 @@ class Reader {
     LZ4F_dctx *dctxPtr;
     BucketInputStream *bucket;
     std::map<std::string, std::shared_ptr<std::string>> metadata;
+
+    pthread_mutex_t mutex;
 };
 
 const class FileOpenError : public std::exception {

--- a/cpp-proio/src/writer.h
+++ b/cpp-proio/src/writer.h
@@ -110,6 +110,8 @@ class Writer {
         pthread_cond_t workerReadyCond;
     } WriteJob;
     WriteJob streamWriteJob;
+
+    pthread_mutex_t mutex;
 };
 
 const uint8_t magicBytes[] = {0xe1, 0xc1, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,


### PR DESCRIPTION
This is just the inclusion of simple mutex locking for methods like Reader::Next() and Writer::Push().