### PR TITLE
Set default compression to gzip

### DIFF
--- a/cpp-proio/CMakeLists.txt
+++ b/cpp-proio/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
-project(proio VERSION 0.4.0)
+project(proio VERSION 0.4.1)
 
 set(CMAKE_CXX_STANDARD 11)
 

--- a/cpp-proio/src/writer.h
+++ b/cpp-proio/src/writer.h
@@ -75,7 +75,7 @@ class Writer {
     /** SetCompression sets the compression type to use for future output
      * buckets.  One of: LZ4, GZIP, or UNCOMPRESSED.
      */
-    void SetCompression(Compression comp = LZ4) { compression = comp; }
+    void SetCompression(Compression comp = GZIP) { compression = comp; }
     /** SetBucketDumpThreshold sets the threshold uncompressed bucket size for
      * automatic compression and output (dump).  I.e., once the size of the
      * uncompressed bucket in memory reaches this threshold, Flush() will be

--- a/go-proio/lcio2proio/main.go
+++ b/go-proio/lcio2proio/main.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	outFile        = flag.String("o", "", "create file to save output to")
-	compLevel      = flag.Int("c", 1, "compression level: 0 for uncompressed, 1 for LZ4 compression, 2 for GZIP compression")
+	compLevel      = flag.Int("c", 2, "compression level: 0 for uncompressed, 1 for LZ4 compression, 2 for GZIP compression")
 	updateInterval = flag.Int("u", 5, "update interval in seconds (set to 0 to disable)")
 )
 

--- a/go-proio/proio-strip/main.go
+++ b/go-proio/proio-strip/main.go
@@ -16,7 +16,7 @@ var (
 	intersection  = flag.Bool("i", false, "only strip the intersection of the specified tags (entries that each have all tags)")
 	keep          = flag.Bool("k", false, "keep only entries with the specified tags, rather than stripping them away")
 	stripMetadata = flag.Bool("m", false, "strip all metadata")
-	compLevel     = flag.Int("c", 1, "output compression level: 0 for uncompressed, 1 for LZ4 compression, 2 for GZIP compression")
+	compLevel     = flag.Int("c", 2, "output compression level: 0 for uncompressed, 1 for LZ4 compression, 2 for GZIP compression")
 )
 
 func printUsage() {

--- a/go-proio/writer.go
+++ b/go-proio/writer.go
@@ -80,7 +80,7 @@ func NewWriter(streamWriter io.Writer) *Writer {
 		metadata:     make(map[string][]byte),
 	}
 
-	writer.SetCompression(LZ4)
+	writer.SetCompression(GZIP)
 	writer.deferUntilClose(writer.Flush)
 
 	return writer

--- a/py-proio/proio/writer.py
+++ b/py-proio/proio/writer.py
@@ -55,7 +55,7 @@ class Writer(object):
 
         self._bucket_events = 0
         self._bucket = io.BytesIO(b'')
-        self.set_compression(proto.BucketHeader.LZ4)
+        self.set_compression(proto.BucketHeader.GZIP)
 
     def __enter__(self):
         return self

--- a/py-proio/setup.py
+++ b/py-proio/setup.py
@@ -7,7 +7,7 @@ models = ['proio.model.' + splitext(basename(model))[0] for model in glob('proio
 models = list(filter(lambda model: model != 'proio.model.__init__', models))
 
 setup(name='proio',
-      version='0.7.2',
+      version='0.7.3',
       description='Library for reading and writing proio files and streams',
       url='http://github.com/decibelcooper/proio',
       author='David Blyth',


### PR DESCRIPTION
This is because of the existing bug #87.  Until this is resolved, LZ4 will be an option, but not default.