### PR TITLE
cpp-proio: revamped thread safety

### DIFF
--- a/cpp-proio/src/reader.h
+++ b/cpp-proio/src/reader.h
@@ -1,8 +1,8 @@
 #ifndef PROIO_READER_H
 #define PROIO_READER_H
 
-#include <pthread.h>
 #include <cstring>
+#include <mutex>
 #include <string>
 
 #include <google/protobuf/io/zero_copy_stream_impl.h>
@@ -35,7 +35,7 @@ class BucketInputStream : public google::protobuf::io::ZeroCopyInputStream {
 
 /** Reader for proio files
  */
-class Reader {
+class Reader : public std::mutex {
    public:
     /** Constructor for providing a file descriptor
      */
@@ -79,8 +79,6 @@ class Reader {
     LZ4F_dctx *dctxPtr;
     BucketInputStream *bucket;
     std::map<std::string, std::shared_ptr<std::string>> metadata;
-
-    pthread_mutex_t mutex;
 };
 
 const class FileOpenError : public std::exception {

--- a/go-proio/example_print_test.go
+++ b/go-proio/example_print_test.go
@@ -4,79 +4,82 @@ import (
 	"fmt"
 
 	"github.com/decibelcooper/proio/go-proio"
-	"github.com/decibelcooper/proio/go-proio/model/lcio"
+	"github.com/decibelcooper/proio/go-proio/model/eic"
 )
 
 func Example_print() {
 	event := proio.NewEvent()
 
-	parent := &lcio.MCParticle{PDG: 443}
-	parentID := event.AddEntry("Particles", parent)
+	parentPDG := int32(443)
+	parent := &eic.Particle{Pdg: &parentPDG}
+	parentID := event.AddEntry("Particle", parent)
 	event.TagEntry(parentID, "MC", "Primary")
 
-	child1 := &lcio.MCParticle{PDG: 11}
-	child2 := &lcio.MCParticle{PDG: -11}
-	childIDs := event.AddEntries("Particles", child1, child2)
+	child1PDG := int32(11)
+	child1 := &eic.Particle{Pdg: &child1PDG}
+	child2PDG := int32(-11)
+	child2 := &eic.Particle{Pdg: &child2PDG}
+	childIDs := event.AddEntries("Particle", child1, child2)
 	for _, id := range childIDs {
-		event.TagEntry(id, "MC", "Simulated")
+		event.TagEntry(id, "MC", "GenStable")
 	}
 
-	parent.Children = append(parent.Children, childIDs...)
-	child1.Parents = append(child1.Parents, parentID)
-	child2.Parents = append(child2.Parents, parentID)
+	parent.Child = append(parent.Child, childIDs...)
+	child1.Parent = append(child1.Parent, parentID)
+	child2.Parent = append(child2.Parent, parentID)
 
 	fmt.Print(event)
 
 	// Output:
-	// ---------- TAG: MC ----------
-	// ID: 1
-	// Entry type: proio.model.lcio.MCParticle
-	// children: 2
-	// children: 3
-	// PDG: 443
-	//
-	// ID: 2
-	// Entry type: proio.model.lcio.MCParticle
-	// parents: 1
-	// PDG: 11
-	//
-	// ID: 3
-	// Entry type: proio.model.lcio.MCParticle
-	// parents: 1
-	// PDG: -11
-	//
-	// ---------- TAG: Particles ----------
-	// ID: 1
-	// Entry type: proio.model.lcio.MCParticle
-	// children: 2
-	// children: 3
-	// PDG: 443
-	//
-	// ID: 2
-	// Entry type: proio.model.lcio.MCParticle
-	// parents: 1
-	// PDG: 11
-	//
-	// ID: 3
-	// Entry type: proio.model.lcio.MCParticle
-	// parents: 1
-	// PDG: -11
-	//
-	// ---------- TAG: Primary ----------
-	// ID: 1
-	// Entry type: proio.model.lcio.MCParticle
-	// children: 2
-	// children: 3
-	// PDG: 443
-	//
-	// ---------- TAG: Simulated ----------
-	// ID: 2
-	// Entry type: proio.model.lcio.MCParticle
-	// parents: 1
-	// PDG: 11
-	//
-	// ID: 3
-	// Entry type: proio.model.lcio.MCParticle
-	// parents: 1
-	// PDG: -11
+    // ---------- TAG: GenStable ----------
+    // ID: 2
+    // Entry type: proio.model.eic.Particle
+    // parent: 1
+    // pdg: 11                             
+    //            
+    // ID: 3      
+    // Entry type: proio.model.eic.Particle
+    // parent: 1
+    // pdg: -11                            
+    //      
+    // ---------- TAG: MC ----------       
+    // ID: 1     
+    // Entry type: proio.model.eic.Particle
+    // child: 2
+    // child: 3
+    // pdg: 443                            
+    //           
+    // ID: 2   
+    // Entry type: proio.model.eic.Particle
+    // parent: 1    
+    // pdg: 11                                               
+    //                            
+    // ID: 3
+    // Entry type: proio.model.eic.Particle
+    // parent: 1
+    // pdg: -11
+
+    // ---------- TAG: Particle ----------
+    // ID: 1
+    // Entry type: proio.model.eic.Particle
+    // child: 2
+    // child: 3
+    // pdg: 443
+
+    // ID: 2
+    // Entry type: proio.model.eic.Particle
+    // parent: 1
+    // pdg: 11
+
+    // ID: 3
+    // Entry type: proio.model.eic.Particle
+    // parent: 1
+    // pdg: -11
+
+    // ---------- TAG: Primary ----------
+    // ID: 1
+    // Entry type: proio.model.eic.Particle
+    // child: 2
+    // child: 3
+    // pdg: 443
 }

--- a/go-proio/example_pushGetInspect_test.go
+++ b/go-proio/example_pushGetInspect_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/decibelcooper/proio/go-proio"
-	"github.com/decibelcooper/proio/go-proio/model/lcio"
+	"github.com/decibelcooper/proio/go-proio/model/eic"
 )
 
 func Example_pushGetInspect() {
@@ -16,20 +16,23 @@ func Example_pushGetInspect() {
 
 	// Create entries and hold onto their IDs for referencing
 
-	parent := &lcio.MCParticle{PDG: 443}
-	parentID := eventOut.AddEntry("Particles", parent)
+	parentPDG := int32(443)
+	parent := &eic.Particle{Pdg: &parentPDG}
+	parentID := eventOut.AddEntry("Particle", parent)
 	eventOut.TagEntry(parentID, "MC", "Primary")
 
-	child1 := &lcio.MCParticle{PDG: 11}
-	child2 := &lcio.MCParticle{PDG: -11}
-	childIDs := eventOut.AddEntries("Particles", child1, child2)
+	child1PDG := int32(11)
+	child1 := &eic.Particle{Pdg: &child1PDG}
+	child2PDG := int32(-11)
+	child2 := &eic.Particle{Pdg: &child2PDG}
+	childIDs := eventOut.AddEntries("Particle", child1, child2)
 	for _, id := range childIDs {
-		eventOut.TagEntry(id, "MC", "Simulated")
+		eventOut.TagEntry(id, "MC", "GenStable")
 	}
 
-	parent.Children = append(parent.Children, childIDs...)
-	child1.Parents = append(child1.Parents, parentID)
-	child2.Parents = append(child2.Parents, parentID)
+	parent.Child = append(parent.Child, childIDs...)
+	child1.Parent = append(child1.Parent, parentID)
+	child2.Parent = append(child2.Parent, parentID)
 
 	writer.Push(eventOut)
 
@@ -43,11 +46,11 @@ func Example_pushGetInspect() {
 	mcParts := eventIn.TaggedEntries("Primary")
 	fmt.Print(len(mcParts), " Primary particle(s)...\n")
 	for i, parentID := range mcParts {
-		part := eventIn.GetEntry(parentID).(*lcio.MCParticle)
-		fmt.Print(i, ". PDG: ", part.PDG, "\n")
-		fmt.Print("  ", len(part.Children), " children...\n")
-		for j, childID := range part.Children {
-			fmt.Print("  ", j, ". PDG: ", eventIn.GetEntry(childID).(*lcio.MCParticle).PDG, "\n")
+		part := eventIn.GetEntry(parentID).(*eic.Particle)
+		fmt.Print(i, ". PDG: ", part.GetPdg(), "\n")
+		fmt.Print("  ", len(part.Child), " children...\n")
+		for j, childID := range part.Child {
+			fmt.Print("  ", j, ". PDG: ", eventIn.GetEntry(childID).(*eic.Particle).GetPdg(), "\n")
 		}
 	}
 

--- a/go-proio/example_scan_test.go
+++ b/go-proio/example_scan_test.go
@@ -5,20 +5,22 @@ import (
 	"fmt"
 
 	"github.com/decibelcooper/proio/go-proio"
-	"github.com/decibelcooper/proio/go-proio/model/lcio"
+	"github.com/decibelcooper/proio/go-proio/model/eic"
 )
 
 func Example_scan() {
 	buffer := &bytes.Buffer{}
 	writer := proio.NewWriter(buffer)
 
+	pdg := int32(443)
 	for i := 0; i < 5; i++ {
 		event := proio.NewEvent()
-		p := &lcio.MCParticle{
-			PDG:    443,
-			Charge: float32(i + 1),
+		charge := float32(i + 1)
+		p := &eic.Particle{
+			Pdg:    &pdg,
+			Charge: &charge,
 		}
-		event.AddEntry("Particles", p)
+		event.AddEntry("Particle", p)
 		writer.Push(event)
 	}
 	writer.Flush()
@@ -30,33 +32,33 @@ func Example_scan() {
 	}
 
 	// Output:
-	// ---------- TAG: Particles ----------
+	// ---------- TAG: Particle ----------
 	// ID: 1
-	// Entry type: proio.model.lcio.MCParticle
-	// PDG: 443
+	// Entry type: proio.model.eic.Particle
+	// pdg: 443
 	// charge: 1
 	//
-	// ---------- TAG: Particles ----------
+	// ---------- TAG: Particle ----------
 	// ID: 1
-	// Entry type: proio.model.lcio.MCParticle
-	// PDG: 443
+	// Entry type: proio.model.eic.Particle
+	// pdg: 443
 	// charge: 2
 	//
-	// ---------- TAG: Particles ----------
+	// ---------- TAG: Particle ----------
 	// ID: 1
-	// Entry type: proio.model.lcio.MCParticle
-	// PDG: 443
+	// Entry type: proio.model.eic.Particle
+	// pdg: 443
 	// charge: 3
 	//
-	// ---------- TAG: Particles ----------
+	// ---------- TAG: Particle ----------
 	// ID: 1
-	// Entry type: proio.model.lcio.MCParticle
-	// PDG: 443
+	// Entry type: proio.model.eic.Particle
+	// pdg: 443
 	// charge: 4
 	//
-	// ---------- TAG: Particles ----------
+	// ---------- TAG: Particle ----------
 	// ID: 1
-	// Entry type: proio.model.lcio.MCParticle
-	// PDG: 443
+	// Entry type: proio.model.eic.Particle
+	// pdg: 443
 	// charge: 5
 }

--- a/go-proio/example_skip_test.go
+++ b/go-proio/example_skip_test.go
@@ -5,20 +5,22 @@ import (
 	"fmt"
 
 	"github.com/decibelcooper/proio/go-proio"
-	"github.com/decibelcooper/proio/go-proio/model/lcio"
+	"github.com/decibelcooper/proio/go-proio/model/eic"
 )
 
 func Example_skip() {
 	buffer := &bytes.Buffer{}
 	writer := proio.NewWriter(buffer)
 
+	pdg := int32(443)
 	for i := 0; i < 5; i++ {
 		event := proio.NewEvent()
-		p := &lcio.MCParticle{
-			PDG:    443,
-			Charge: float32(i + 1),
+		charge := float32(i + 1)
+		p := &eic.Particle{
+			Pdg:    &pdg,
+			Charge: &charge,
 		}
-		event.AddEntry("Particles", p)
+		event.AddEntry("Particle", p)
 		writer.Push(event)
 	}
 	writer.Flush()
@@ -34,15 +36,15 @@ func Example_skip() {
 	fmt.Print(event)
 
 	// Output:
-	// ---------- TAG: Particles ----------
+	// ---------- TAG: Particle ----------
 	// ID: 1
-	// Entry type: proio.model.lcio.MCParticle
-	// PDG: 443
+	// Entry type: proio.model.eic.Particle
+	// pdg: 443
 	// charge: 4
 	//
-	// ---------- TAG: Particles ----------
+	// ---------- TAG: Particle ----------
 	// ID: 1
-	// Entry type: proio.model.lcio.MCParticle
-	// PDG: 443
+	// Entry type: proio.model.eic.Particle
+	// pdg: 443
 	// charge: 1
 }

--- a/go-proio/writeRead_test.go
+++ b/go-proio/writeRead_test.go
@@ -609,8 +609,8 @@ func TestScan1(t *testing.T) {
 	done := make(chan int)
 	var eventOutMutex sync.Mutex
 
-	scanner := func() {
-		for event := range reader.ScanEvents() {
+	scanner := func(c <-chan *Event) {
+		for event := range c {
 			eventOutMutex.Lock()
 			if event.String() != eventOut.String() {
 				t.Error("Event corrupted")
@@ -621,8 +621,9 @@ func TestScan1(t *testing.T) {
 		done <- 1
 	}
 
-	go scanner()
-	go scanner()
+	c := reader.ScanEvents()
+	go scanner(c)
+	go scanner(c)
 
 	totEvtsRead := 0
 	totDone := 0
@@ -686,8 +687,8 @@ func TestScan2(t *testing.T) {
 	done := make(chan int)
 	var eventOutMutex sync.Mutex
 
-	scanner := func() {
-		for event := range reader.ScanEvents() {
+	scanner := func(c <-chan *Event) {
+		for event := range c {
 			eventOutMutex.Lock()
 			if event.String() != eventOut.String() {
 				t.Error("Event corrupted")
@@ -698,8 +699,9 @@ func TestScan2(t *testing.T) {
 		done <- 1
 	}
 
-	go scanner()
-	go scanner()
+	c := reader.ScanEvents()
+	go scanner(c)
+	go scanner(c)
 
 	totEvtsRead := 0
 	totDone := 0
@@ -760,23 +762,26 @@ func TestScan3(t *testing.T) {
 	done := make(chan int)
 	var eventOutMutex sync.Mutex
 
-	scanner := func() {
-		for event := range reader.ScanEvents() {
+	scanner := func(c <-chan *Event) {
+		for event := range c {
 			eventOutMutex.Lock()
 			if event.String() != eventOut.String() {
 				t.Error("Event corrupted")
 			}
 			eventOutMutex.Unlock()
 			evtsRead <- 1
+			reader.Lock()
 			if nSkipped, _ := reader.Skip(1); nSkipped == 1 {
 				evtsRead <- 1
 			}
+			reader.Unlock()
 		}
 		done <- 1
 	}
 
-	go scanner()
-	go scanner()
+	c := reader.ScanEvents()
+	go scanner(c)
+	go scanner(c)
 
 	totEvtsRead := 0
 	totDone := 0
@@ -840,23 +845,26 @@ func TestScan4(t *testing.T) {
 	done := make(chan int)
 	var eventOutMutex sync.Mutex
 
-	scanner := func() {
-		for event := range reader.ScanEvents() {
+	scanner := func(c <-chan *Event) {
+		for event := range c {
 			eventOutMutex.Lock()
 			if event.String() != eventOut.String() {
 				t.Error("Event corrupted")
 			}
 			eventOutMutex.Unlock()
 			evtsRead <- 1
+			reader.Lock()
 			if nSkipped, _ := reader.Skip(1); nSkipped == 1 {
 				evtsRead <- 1
 			}
+			reader.Unlock()
 		}
 		done <- 1
 	}
 
-	go scanner()
-	go scanner()
+	c := reader.ScanEvents()
+	go scanner(c)
+	go scanner(c)
 
 	totEvtsRead := 0
 	totDone := 0
@@ -917,8 +925,8 @@ func TestScan5(t *testing.T) {
 	done := make(chan int)
 	var eventOutMutex sync.Mutex
 
-	scanner := func() {
-		for event := range reader.ScanEvents() {
+	scanner := func(c <-chan *Event) {
+		for event := range c {
 			eventOutMutex.Lock()
 			if event.String() != eventOut.String() {
 				t.Error("Event corrupted")
@@ -929,8 +937,9 @@ func TestScan5(t *testing.T) {
 		done <- 1
 	}
 
-	go scanner()
-	go scanner()
+	c := reader.ScanEvents()
+	go scanner(c)
+	go scanner(c)
 
 	totEvtsRead := 0
 	totDone := 0

--- a/go-proio/writer.go
+++ b/go-proio/writer.go
@@ -22,7 +22,9 @@ const (
 	LZ4
 )
 
-// Writer serves to write Events into the proio format.
+// Writer serves to write Events into a stream in the proio format.  The Writer
+// is not inherently thread safe, but it conveniently embeds sync.Mutex so that
+// it can be locked and unlocked.
 type Writer struct {
 	streamWriter io.Writer
 	bucket       *bytes.Buffer
@@ -106,9 +108,6 @@ func (wrt *Writer) SetCompression(comp Compression) error {
 // Serialize the given Event.  Once this is performed, changes to the Event in
 // memory are not reflected in the output stream.
 func (wrt *Writer) Push(event *Event) error {
-	wrt.Lock()
-	defer wrt.Unlock()
-
 	for key, value := range event.Metadata {
 		if !reflect.DeepEqual(wrt.metadata[key], value) {
 			wrt.PushMetadata(key, value)


### PR DESCRIPTION
Now uses STL thread stuff.  This mostly affects the Writer class, which uses a separate thready for carrying out writing to stream.

Also, Readers and Writers no longer have any thread safe methods, but instead they inherit public std::mutex.