### PR TITLE
cpp-proio: added Event::Free method to free recycled entry messages

### DIFF
--- a/cpp-proio/CMakeLists.txt
+++ b/cpp-proio/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
-project(proio VERSION 0.5.1)
+project(proio VERSION 0.6.0)
 
 set(CMAKE_CXX_STANDARD 11)
 

--- a/cpp-proio/src/event.cc
+++ b/cpp-proio/src/event.cc
@@ -128,6 +128,16 @@ std::vector<std::string> Event::EntryTags(uint64_t id) {
 
 void Event::DeleteTag(std::string tag) { eventProto->mutable_tags()->erase(tag); }
 
+Message *Event::Free(const Descriptor *desc) {
+    std::vector<Message *> &storeEntries = store[desc];
+    if (storeEntries.size() > 0) {
+        Message *entry = storeEntries.back();
+        storeEntries.pop_back();
+        return entry;
+    } else
+        return NULL;
+}
+
 std::string Event::String() {
     std::string printString;
     for (auto tag : Tags()) {

--- a/cpp-proio/src/event.h
+++ b/cpp-proio/src/event.h
@@ -49,6 +49,11 @@ class Event {
     /** DeleteTag removes a tag from the Event.
      */
     void DeleteTag(std::string tag);
+    /** Free returns an allocated and cleared entry Message of the type
+     * described by the given Descriptor, or NULL if no already-allocated
+     * messages of this type are available.
+     */
+    google::protobuf::Message *Free(const google::protobuf::Descriptor *desc);
     /** Metadata returns a mapping from a string key to a pointer to a string
      * that contains the metadata, by reference.  These metadata are all the
      * entries received on the stream up to this Event.


### PR DESCRIPTION
Messages are recycled when the event is pushed or Event::Clear is called

This PR resolves #107 