### PR TITLE
Model: EIC: Reduced precision

### DIFF
--- a/model/eic.proto
+++ b/model/eic.proto
@@ -16,9 +16,9 @@ message Particle {
     // position in mm and time in ns
     optional XYZTD vertex = 4;
     // momentum in GeV
-    optional XYZD p = 5;
+    optional XYZF p = 5;
     // mass in GeV
-    optional double mass = 6;
+    optional float mass = 6;
     // charge in units of e
     optional float charge = 7;
     optional XYZF spin = 8;


### PR DESCRIPTION

 Hi, David

 If I do this change (converting 4-momenta and masses to float) then the file size for 50,000 events is reduced from 42 MB to 30 MB. This is a large improvement (the file sizes will be even smaller than for ProMC). I suggest this change.

Sergei

