### PR TITLE
cpp-proio: reader: fixed metadata issue

### DIFF
--- a/cpp-proio/CMakeLists.txt
+++ b/cpp-proio/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
-project(proio VERSION 0.7.2)
+project(proio VERSION 0.7.3)
 
 set(CMAKE_CXX_STANDARD 11)
 

--- a/cpp-proio/src/reader.cc
+++ b/cpp-proio/src/reader.cc
@@ -96,6 +96,7 @@ void Reader::SeekToStart() {
     delete fileStream;
     if (lseek(fd, 0, SEEK_SET) == -1) throw seekError;
     fileStream = new io::FileInputStream(fd);
+    metadata.clear();
     bucketIndex = 0;
     readHeader();
 }

--- a/cpp-proio/src/tests/metadata/main.cc
+++ b/cpp-proio/src/tests/metadata/main.cc
@@ -124,7 +124,54 @@ void pushUpdate2() {
     delete event;
 }
 
+void pushUpdateRestart1() {
+    char filename[] = "pushupdaterestart1XXXXXX";
+    auto writer = new proio::Writer(mkstemp(filename));
+
+    writer->PushMetadata("key1", "value1");
+    writer->PushMetadata("key2", "value2");
+    auto event = new proio::Event();
+    writer->Push(event);
+    writer->PushMetadata("key2", "value3");
+    writer->Push(event);
+    std::string value4 = "value4";
+    std::string value5 = "value5";
+    std::string value6 = "value6";
+    writer->PushMetadata("key1", value4);
+    writer->PushMetadata("key2", value5);
+    writer->PushMetadata("key3", value6);
+    writer->Push(event);
+
+    delete writer;
+    delete event;
+    auto reader = new proio::Reader(filename);
+
+    delete reader->Next();
+    delete reader->Next();
+    delete reader->Next();
+    reader->SeekToStart();
+
+    auto event1 = reader->Next();
+    auto event2 = reader->Next();
+    auto event3 = reader->Next();
+    assert(event1->Metadata().at("key1")->compare("value1") == 0);
+    assert(event1->Metadata().at("key2")->compare("value2") == 0);
+    assert(event1->Metadata().count("key3") == 0);
+    assert(event2->Metadata().at("key1")->compare("value1") == 0);
+    assert(event2->Metadata().at("key2")->compare("value3") == 0);
+    assert(event2->Metadata().count("key3") == 0);
+    assert(event3->Metadata().at("key1")->compare("value4") == 0);
+    assert(event3->Metadata().at("key2")->compare("value5") == 0);
+    assert(event3->Metadata().at("key3")->compare("value6") == 0);
+
+    delete event1;
+    delete event2;
+    delete event3;
+    delete reader;
+    remove(filename);
+}
 int main() {
     pushUpdate1();
     pushUpdate2();
+    pushUpdateRestart1();
 }


### PR DESCRIPTION
...where metadata from later events could get associated with earlier events if SeekToStart() is used.