### PR TITLE
cpp-proio: fix for slow Skip() calls

### DIFF
--- a/cpp-proio/src/reader.cc
+++ b/cpp-proio/src/reader.cc
@@ -82,6 +82,8 @@ uint64_t Reader::Skip(uint64_t nEvents) {
             uint64_t nBucketEvents = bucketHeader->nevents();
             bucketIndex -= nBucketEvents;
             nSkipped += nBucketEvents - startIndex;
+            if (nBucketEvents > 0 && bucket->BytesRemaining() == 0)
+                if (!fileStream->Skip(bucketHeader->bucketsize())) throw ioError;
         }
         readHeader();
         if (!bucketHeader) return nSkipped;

--- a/cpp-proio/src/reader.h
+++ b/cpp-proio/src/reader.h
@@ -105,6 +105,10 @@ const class BadLZ4FrameError : public std::exception {
 const class SeekError : public std::exception {
     virtual const char *what() const throw() { return "Failed to seek file"; }
 } seekError;
+
+const class IOError : public std::exception {
+    virtual const char *what() const throw() { return "Unexpected IO Error"; }
+} ioError;
 }  // namespace proio
 
 #endif  // PROIO_READER_H


### PR DESCRIPTION
Problem was that bucket bytes were not actually being skipped, and it was falling back on syncing to magic number.