### PR TITLE
py-proio: removed reader.next() in favor of built-in next()

### DIFF
--- a/py-proio/README.md
+++ b/py-proio/README.md
@@ -121,17 +121,16 @@ with proio.Writer(test_filename) as writer:
     child2.parent.append(parent_id)
 
     writer.push(event)
-    
-with proio.Reader(test_filename) as reader:
-    event = reader.next()
-    
-    parts = event.tagged_entries('Particle')
-    print('%i particle(s)...' % len(parts))
-    for i in range(0, len(parts)):
-        part = event.get_entry(parts[i])
-        print('%i. PDG Code: %i' % (i, part.pdg))
 
-        print('  %i children...' % len(part.child))
-        for j in range(0, len(part.child)):
-            print('  %i. PDG Code: %i' % (j, event.get_entry(part.child[j]).pdg))
+with proio.Reader(test_filename) as reader:
+    for event in reader:
+        parts = event.tagged_entries('Particle')
+        print('%i particle(s)...' % len(parts))
+        for i in range(0, len(parts)):
+            part = event.get_entry(parts[i])
+            print('%i. PDG Code: %i' % (i, part.pdg))
+
+            print('  %i children...' % len(part.child))
+            for j in range(0, len(part.child)):
+                print('  %i. PDG Code: %i' % (j, event.get_entry(part.child[j]).pdg))
 ```

--- a/py-proio/proio/reader.py
+++ b/py-proio/proio/reader.py
@@ -47,6 +47,23 @@ class Reader(object):
     def __exit__(self, exception_type, exception_value, traceback):
         self.close()
 
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        """
+        :return: the next event
+        :rtype: Event
+        """
+        event = self._read_from_bucket(True)
+        if event is None:
+            raise StopIteration
+        return event
+
+    if sys.version_info[0] == 2:
+        def next(self):
+            return self.__next__()
+
     def close(self):
         """
         closes the underlying input file object.
@@ -56,16 +73,6 @@ class Reader(object):
                 self._stream_reader.close()
         except:
             pass
-
-    def next(self):
-        """
-        :return: the next event
-        :rtype: Event
-        """
-        event = self._read_from_bucket(True)
-        if event is None:
-            raise StopIteration
-        return event
 
     def next_header(self):
         """
@@ -205,8 +212,3 @@ class Reader(object):
 
         return n_read
 
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        return self.next()

--- a/py-proio/tests/test_metadata.py
+++ b/py-proio/tests/test_metadata.py
@@ -17,9 +17,9 @@ def test_next_header1():
     with proio.Reader(fileobj = buf) as reader:
         header = reader.next_header()
         assert(header.nEvents == 2)
-        assert(reader.next() != None)
+        assert(reader.__next__() != None)
         try:
-            reader.next()
+            reader.__next__()
             assert(False)
         except StopIteration:
             pass
@@ -36,11 +36,11 @@ def test_next_header2():
     buf.seek(0, 0)
 
     with proio.Reader(fileobj = buf) as reader:
-        assert(reader.next() != None)
+        assert(reader.__next__() != None)
         header = reader.next_header()
         assert(header.nEvents == 1)
         try:
-            reader.next()
+            reader.__next__()
             assert(False)
         except StopIteration:
             pass

--- a/py-proio/tests/test_push_get.py
+++ b/py-proio/tests/test_push_get.py
@@ -92,7 +92,7 @@ def push_get1(comp):
 
     with proio.Reader(fileobj = buf) as reader:
         for i in range(0, len(eventsOut)):
-            event = reader.next()
+            event = reader.__next__()
             assert event != None
             assert event.__str__() == eventsOut[i].__str__()
 
@@ -131,7 +131,7 @@ def push_get2(comp):
 
     with proio.Reader(fileobj = buf) as reader:
         for i in range(0, len(eventsOut)):
-            event = reader.next()
+            event = reader.__next__()
             assert event != None
             assert event.__str__() == eventsOut[i].__str__()
 
@@ -178,7 +178,7 @@ def push_get3(comp):
 
     with proio.Reader(fileobj = buf2) as reader:
         for i in range(0, len(eventsOut)):
-            event = reader.next()
+            event = reader.__next__()
             assert event != None
             assert event.__str__() == eventsOut[i].__str__()
 
@@ -216,7 +216,7 @@ def push_skip_get1(comp):
 
     with proio.Reader(fileobj = buf) as reader:
         reader.skip(1)
-        event = reader.next()
+        event = reader.__next__()
         assert event != None
         assert event.__str__() == eventsOut[1].__str__()
 
@@ -255,7 +255,7 @@ def push_skip_get2(comp):
 
     with proio.Reader(fileobj = buf) as reader:
         reader.skip(1)
-        event = reader.next()
+        event = reader.__next__()
         assert event != None
         assert event.__str__() == eventsOut[1].__str__()
 
@@ -298,13 +298,13 @@ def push_seek_skip_get1(comp):
     buf.seek(0, 0)
 
     with proio.Reader(fileobj = buf) as reader:
-        event = reader.next()
+        event = reader.__next__()
         assert event != None
         assert event.__str__() == eventsOut[0].__str__()
 
         reader.seek_to_start()
         reader.skip(2)
-        event = reader.next()
+        event = reader.__next__()
         assert event != None
         assert event.__str__() == eventsOut[2].__str__()
 

--- a/py-proio/tests/test_ref_deref.py
+++ b/py-proio/tests/test_ref_deref.py
@@ -25,7 +25,7 @@ def test_ref_deref1():
     buf.seek(0, 0)
     
     with proio.Reader(fileobj = buf) as reader:
-        event = reader.next()
+        event = reader.__next__()
         assert event != None
 
         mc_particles = event.tagged_entries('MCParticles')


### PR DESCRIPTION
Preivously, I had reader.__next__() call reader.next().  At some point this started causing a recursive loop since for some reason calling reader.next() started calling reader.__next__().  So reader.next() has been removed in favor of using next(reader)